### PR TITLE
ASE LJ buggfix

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,12 +11,12 @@ a : 5.256E-10 # Lattice constant
 latticeconstants : [3.569, 4.569, 5.569, 50, 60, 70] #[a, b, c, alpha, beta, gamma]
 structure : "FCC"
 directions : [[1,0,0], [0,1,0], [0,0,1]] #use Miller-Bravais for hex-structure
-symbol : "Ar"
+symbol : "Cu"
 make_traj: True
 pbc : True
-size : 4
-temperature_K : 40
-potential: 'LJ'
+size : 1
+temperature_K : 300
+potential:
 run_density: False
 run_MD: True
 run_pressure: True

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def MD():
 
     use_asap = args.asap
 
-    use_asap = True
+    use_asap = False
 
     atomic_number = parsed_config_file["atomic_number"]
     epsilon = parsed_config_file["epsilon"] * units.eV
@@ -99,7 +99,7 @@ def MD():
     else:
         print("Running with ase")
         from ase.calculators.emt import EMT
-        from ase.calculators.emt import LennardJones
+        from ase.calculators.lj import LennardJones
         from ase.md.verlet import VelocityVerlet
 
     size = parsed_config_file["size"]
@@ -110,11 +110,12 @@ def MD():
     # Describe the interatomic interactions with the Effective Medium Theory
 
     potential = parsed_config_file["potential"]
-    known_potentials = {
-      'EMT' : EMT(),
-      'LJ' : LennardJones([atomic_number], [epsilon], [sigma],
+    if potential :
+        known_potentials = {
+        'EMT' : EMT(),
+        'LJ' : LennardJones([atomic_number], [epsilon], [sigma],
                     rCut=cutoff, modified=True,),
-    }
+        }
 
     atoms.calc = known_potentials[potential] if potential else EMT()
 


### PR DESCRIPTION
Implemented temporary work-around for difference in LennardJones potential between ASAP and ASE so that people who use ASE can still run main. Currently the program always uses EMT if running with ASE. Leave potential in config.yaml empty if running with ASE.